### PR TITLE
Arrow Raise validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 
     implementation "org.jooq:jooq:3.17.6"
 
+    implementation "io.arrow-kt:arrow-core:1.2.0"
+
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/src/main/java/com/gildedrose/domain/ID.kt
+++ b/src/main/java/com/gildedrose/domain/ID.kt
@@ -1,11 +1,16 @@
 package com.gildedrose.domain
 
+import arrow.core.raise.Raise
+
 @JvmInline
 value class ID<@Suppress("unused") T>(val value: NonBlankString) {
 
     companion object {
         operator fun <T> invoke(value: String): ID<T>? =
             NonBlankString(value)?.let { ID<T>(it) }
+
+        context(Raise<String>)
+        operator fun <T> invoke(value: String): ID<T> = ID(NonBlankString(value))
     }
 
     override fun toString() = value.toString()

--- a/src/main/java/com/gildedrose/domain/NonBlankString.kt
+++ b/src/main/java/com/gildedrose/domain/NonBlankString.kt
@@ -1,5 +1,7 @@
 package com.gildedrose.domain
 
+import arrow.core.raise.Raise
+
 @JvmInline
 value class NonBlankString
 private constructor(val value: String) : CharSequence by value {
@@ -7,6 +9,11 @@ private constructor(val value: String) : CharSequence by value {
         operator fun invoke(value: String): NonBlankString? =
             if (value.isNotBlank()) NonBlankString(value)
             else null
+
+        context(Raise<String>)
+        operator fun invoke(value: String): NonBlankString =
+            if (value.isNotBlank()) NonBlankString(value)
+            else raise("String cannot be blank")
     }
 
     init {

--- a/src/main/java/com/gildedrose/domain/NonNegativeInt.kt
+++ b/src/main/java/com/gildedrose/domain/NonNegativeInt.kt
@@ -1,5 +1,7 @@
 package com.gildedrose.domain
 
+import arrow.core.raise.Raise
+
 @JvmInline
 value class NonNegativeInt
 private constructor(val value: Int)  {
@@ -7,6 +9,11 @@ private constructor(val value: Int)  {
         operator fun invoke(value: Int): NonNegativeInt? =
             if (value >= 0) NonNegativeInt(value)
             else null
+
+        context(Raise<String>)
+        operator fun invoke(value: Int): NonNegativeInt =
+            if (value >= 0) NonNegativeInt(value)
+            else raise("Integer cannot be negative")
     }
 
     init {

--- a/src/main/java/com/gildedrose/domain/Quality.kt
+++ b/src/main/java/com/gildedrose/domain/Quality.kt
@@ -1,5 +1,7 @@
 package com.gildedrose.domain
 
+import arrow.core.raise.Raise
+
 @JvmInline
 value class Quality(
     private val value: NonNegativeInt
@@ -11,6 +13,10 @@ value class Quality(
 
         operator fun invoke(value: Int): Quality? =
             NonNegativeInt(value)?.let { Quality(it) }
+
+        context(Raise<String>)
+        operator fun invoke(value: Int): Quality =
+            Quality(NonNegativeInt(value))
     }
 
     override fun toString() = value.toString()

--- a/src/main/java/com/gildedrose/routes.kt
+++ b/src/main/java/com/gildedrose/routes.kt
@@ -1,23 +1,25 @@
 package com.gildedrose
 
+import arrow.core.raise.*
 import com.gildedrose.domain.*
 import com.gildedrose.foundation.AnalyticsEvent
+import com.gildedrose.foundation.magic
 import com.gildedrose.foundation.runIO
 import com.gildedrose.http.ResponseErrors
 import com.gildedrose.http.ResponseErrors.withError
 import com.gildedrose.http.catchAll
 import com.gildedrose.http.reportHttpTransactions
 import com.gildedrose.rendering.render
+import java.time.Duration
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
 import org.http4k.core.*
+import org.http4k.core.body.Form
 import org.http4k.core.body.form
 import org.http4k.filter.ServerFilters
 import org.http4k.lens.*
-import org.http4k.lens.ParamMeta.IntegerParam
 import org.http4k.routing.bind
 import org.http4k.routing.routes
-import java.time.Duration
-import java.time.LocalDate
-
 
 val App.routes: HttpHandler
     get() = ServerFilters.RequestTracing()
@@ -33,39 +35,53 @@ val App.routes: HttpHandler
             )
         )
 
-internal fun App.addHandler(request: Request): Response {
-    val idLens = FormField.nonBlankString().map { ID<Item>(it) }.required("new-itemId")
-    val nameLens = FormField.nonBlankString().required("new-itemName")
-    val sellByLens = FormField.nullOnEmptyLocalDate().optional("new-itemSellBy")
-    val qualityLens = FormField.nonNegativeInt().map { Quality(it) }.required("new-itemQuality")
-    val formBody = Body.webForm(Validator.Feedback, idLens, nameLens, sellByLens, qualityLens).toLens()
-    val form: WebForm = formBody(request)
-    if (form.errors.isNotEmpty())
-        return Response(Status.BAD_REQUEST).withError(NewItemFailedEvent(form.errors.toString()))
-
-    val item = Item(idLens(form), nameLens(form), sellByLens(form), qualityLens(form))
-    runIO {
-        addItem(newItem = item)
-    }
-    return Response(Status.SEE_OTHER).header("Location", "/")
+internal fun App.addHandler(request: Request): Response = recover({
+    val form = request.form()
+    val item = Item(
+        form.required("new-itemId") { ID(it) },
+        form.required("new-itemName") { NonBlankString(it) },
+        form.optional("new-itemSellBy") { it?.ifEmpty { null }?.toLocalDate() },
+        form.required("new-itemQuality") { Quality(it.toIntSafe()) })
+    runIO { addItem(newItem = item) }
+    Response(Status.SEE_OTHER).header("Location", "/")
+}) { error ->
+    Response(Status.BAD_REQUEST).withError(NewItemFailedEvent(error))
 }
 
 data class NewItemFailedEvent(val message: String) : AnalyticsEvent
 
-fun FormField.nonNegativeInt() =
-    mapWithNewMeta(
-        BiDiMapping<String, NonNegativeInt>(
-            { NonNegativeInt(it.toInt()) ?: throw IllegalArgumentException("Integer cannot be negative") },
-            NonNegativeInt::toString
-        ), IntegerParam
-    )
+context(Raise<String>)
+fun Form.required(name: String): String =
+    findSingle(name) ?: raise("formData '$name' is required")
 
-fun FormField.nullOnEmptyLocalDate() = string().map { if (it.isEmpty()) null else LocalDate.parse(it) }
+fun Form.optional(name: String): String? = findSingle(name)
 
-fun FormField.nonBlankString(): BiDiLensSpec<WebForm, NonBlankString> =
-    map(BiDiMapping<String, NonBlankString>({ s: String ->
-        NonBlankString(s) ?: throw IllegalArgumentException("String cannot be blank")
-    }, { it.toString() }))
+// The following 2 functions take care of including the invalid field name in the error message.
+context(Raise<String>)
+fun <T> Form.required(name: String, transform: context(Raise<String>) (String) -> T): T {
+    val value = required(name)
+    return withError({ e -> "formData '$name': $e" }) {
+        transform(magic(), value)
+    }
+}
+
+context(Raise<String>)
+fun <T> Form.optional(name: String, transform: context(Raise<String>) (String?) -> T): T {
+    val value = optional(name)
+    return withError({ e -> "formData '$name': $e" }) {
+        transform(magic(), value)
+    }
+}
+
+// In a Raise world, these would already be defined instead of their exception-throwing counterparts
+context(Raise<String>)
+fun String.toLocalDate(): LocalDate =
+    // This catch function is reified! So it only catches DateTimeParseException
+    catch<DateTimeParseException, _>({ LocalDate.parse(this) }) { raise("Invalid date format") }
+
+context(Raise<String>)
+fun String.toIntSafe(): Int =
+    catch<NumberFormatException, _>({ toInt() }) { raise("Invalid number format") }
 
 private fun App.listHandler(
     @Suppress("UNUSED_PARAMETER") request: Request

--- a/src/test/java/com/gildedrose/AddItemTests.kt
+++ b/src/test/java/com/gildedrose/AddItemTests.kt
@@ -186,7 +186,7 @@ class AddItemTests {
             app.addHandler(postWithTwoMissingFields),
             hasStatus(Status.BAD_REQUEST) and
                 hasAttachedError(
-                    NewItemFailedEvent("[formData 'new-itemId' is required, formData 'new-itemQuality' must be integer]")
+                    NewItemFailedEvent("[formData 'new-itemId' is required, formData 'new-itemQuality': Invalid number format]")
                 )
         )
     }


### PR DESCRIPTION
Few things:
- The key that makes this code nice is that it uses `Raise` at every step that can fail, instead of relying on nullable types or exceptions. It thus allows you to report errors transparently, while still being compile-time checked, and playing nicely with lambdas, coroutines, etc.
- Instead of  `Raise<String>`, you can introduce your own Domain Errors later on. The nice thing is, vs http4k's lenses, you get to have typed errors. 

- There are a few functions like `Form.required`, `Form.optional` `String.toIntSafe` and so on that are needed for convenience, but they're reusable. 

- You can see the power of `Raise` in the `Form.required` `transform` variation, which prepends the field name to the error message. That would have been harder with exceptions. Raise really shines in transforming errors, especially between different domain layers, and the String-based approach here really doesn't do it justice.

- You don't need to use the  `Form.required` `transform` variation, which might make the code look a bit simpler. It's as simple as changing `required("new-itemId") { ID(it) }` to `ID(required("new-itemId"))`, but would lose out on the `formData 'new-itemId': ` in the error message, which your version didn't have anyways.

- The last commit in the PR has error accumulation, but if you don't need that, you can simply use the first commit only (and modify the test, of course).

- `Raise` does use exceptions under the hood, but it also plays nicely with coroutines, and mostly gets out of your way, while, I suspect, lenses wouldn't really support coroutines.