### PR TITLE
Use Arrow's Raise instead of Result4k in most places

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 
     implementation "org.jooq:jooq:3.17.6"
 
+    implementation "io.arrow-kt:arrow-core:1.2.0"
+
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/src/main/java/com/gildedrose/domain/ID.kt
+++ b/src/main/java/com/gildedrose/domain/ID.kt
@@ -1,11 +1,16 @@
 package com.gildedrose.domain
 
+import arrow.core.raise.Raise
+
 @JvmInline
 value class ID<@Suppress("unused") T>(val value: NonBlankString) {
 
     companion object {
         operator fun <T> invoke(value: String): ID<T>? =
             NonBlankString(value)?.let { ID<T>(it) }
+
+        context(Raise<String>)
+        operator fun <T> invoke(value: String): ID<T> = ID(NonBlankString(value))
     }
 
     override fun toString() = value.toString()

--- a/src/main/java/com/gildedrose/domain/NonBlankString.kt
+++ b/src/main/java/com/gildedrose/domain/NonBlankString.kt
@@ -1,5 +1,7 @@
 package com.gildedrose.domain
 
+import arrow.core.raise.Raise
+
 @JvmInline
 value class NonBlankString
 private constructor(val value: String) : CharSequence by value {
@@ -7,6 +9,11 @@ private constructor(val value: String) : CharSequence by value {
         operator fun invoke(value: String): NonBlankString? =
             if (value.isNotBlank()) NonBlankString(value)
             else null
+
+        context(Raise<String>)
+        operator fun invoke(value: String): NonBlankString =
+            if (value.isNotBlank()) NonBlankString(value)
+            else raise("String cannot be blank")
     }
 
     init {

--- a/src/main/java/com/gildedrose/domain/NonNegativeInt.kt
+++ b/src/main/java/com/gildedrose/domain/NonNegativeInt.kt
@@ -1,5 +1,7 @@
 package com.gildedrose.domain
 
+import arrow.core.raise.Raise
+
 @JvmInline
 value class NonNegativeInt
 private constructor(val value: Int)  {
@@ -7,6 +9,11 @@ private constructor(val value: Int)  {
         operator fun invoke(value: Int): NonNegativeInt? =
             if (value >= 0) NonNegativeInt(value)
             else null
+
+        context(Raise<String>)
+        operator fun invoke(value: Int): NonNegativeInt =
+            if (value >= 0) NonNegativeInt(value)
+            else raise("Integer cannot be negative")
     }
 
     init {

--- a/src/main/java/com/gildedrose/domain/Quality.kt
+++ b/src/main/java/com/gildedrose/domain/Quality.kt
@@ -1,5 +1,7 @@
 package com.gildedrose.domain
 
+import arrow.core.raise.Raise
+
 @JvmInline
 value class Quality(
     private val value: NonNegativeInt
@@ -11,6 +13,10 @@ value class Quality(
 
         operator fun invoke(value: Int): Quality? =
             NonNegativeInt(value)?.let { Quality(it) }
+
+        context(Raise<String>)
+        operator fun invoke(value: Int): Quality =
+            Quality(NonNegativeInt(value))
     }
 
     override fun toString() = value.toString()

--- a/src/main/java/com/gildedrose/foundation/contexts.kt
+++ b/src/main/java/com/gildedrose/foundation/contexts.kt
@@ -1,12 +1,10 @@
+@file:Suppress("SUBTYPING_BETWEEN_CONTEXT_RECEIVERS")
 package com.gildedrose.foundation
 
 context(C) fun <C> magic() : C = this@C
 
-// replaced with wrappedWith
-fun <C, T, R> (context(C) (T) -> R).transformedBy(
-    transform: ((T) -> R) -> (T) -> R
-): context(C) (T) -> R = { outerIt ->
-    transform { innerIt: T ->
-        this(magic(), innerIt)
-    }(outerIt)
-}
+context(C)
+operator fun <C, T, R> (context(C) (T) -> R).invoke(t: T) : R = this(magic<C>(), t)
+
+context(C1, C2, C3)
+operator fun <C1, C2, C3, T, R> (context(C1, C2, C3) (T) -> R).invoke(t: T) : R = this(magic<C1>(), magic<C2>(), magic<C3>(), t)

--- a/src/main/java/com/gildedrose/foundation/raise.kt
+++ b/src/main/java/com/gildedrose/foundation/raise.kt
@@ -1,0 +1,28 @@
+package com.gildedrose.foundation
+
+import arrow.core.nonFatalOrThrow
+import arrow.core.raise.Raise
+import arrow.core.raise.catch
+import arrow.core.raise.fold
+import arrow.core.raise.merge
+import dev.forkhandles.result4k.*
+
+inline fun <R, E> result4k(block: Raise<E>.() -> R): Result4k<R, E> =
+    fold(block, ::Failure, ::Success)
+
+// This doesn't catch fatal exceptions, like coroutine cancellation or raised errors, which is good.
+inline fun <R> resultCatch(block: () -> R): Result4k<R, Exception> =
+    resultFrom(block).peekFailure { it.nonFatalOrThrow() }
+
+context(Raise<E>)
+fun <R, E> Result4k<R, E>.bind(): R = recover(::raise)
+
+context(Raise<Error>)
+inline fun <reified Exception : Throwable, Error, Result> withException(
+    transform: (Exception) -> Error,
+    block: () -> Result
+): Result = catch<Exception, Result>(block) { raise(transform(it)) }
+
+inline fun ignoreErrors(block: Raise<Any?>.() -> Unit) {
+  merge(block)
+}

--- a/src/main/java/com/gildedrose/persistence/Items.kt
+++ b/src/main/java/com/gildedrose/persistence/Items.kt
@@ -1,8 +1,8 @@
 package com.gildedrose.persistence
 
+import arrow.core.raise.Raise
 import com.gildedrose.domain.StockList
 import com.gildedrose.foundation.IO
-import dev.forkhandles.result4k.Result
 
 /**
  * The transaction that Items methods are running in.
@@ -21,9 +21,9 @@ interface Items<out TX: TXContext> {
 
     fun <R> inTransaction(block: context(TX) () -> R): R
 
-    context(IO, TX) fun save(
-        stockList: StockList
-    ): Result<StockList, StockListLoadingError.IOError>
+    context(IO, TX, Raise<StockListLoadingError.IOError>)
+    fun save(stockList: StockList): StockList
 
-    context(IO, TX) fun load(): Result<StockList, StockListLoadingError>
+    context(IO, TX, Raise<StockListLoadingError>)
+    fun load(): StockList
 }

--- a/src/main/java/com/gildedrose/persistence/StockFileItems.kt
+++ b/src/main/java/com/gildedrose/persistence/StockFileItems.kt
@@ -1,20 +1,17 @@
 package com.gildedrose.persistence
 
+import arrow.core.raise.Raise
 import com.gildedrose.domain.StockList
 import com.gildedrose.foundation.IO
-import dev.forkhandles.result4k.Failure
-import dev.forkhandles.result4k.Result
-import dev.forkhandles.result4k.Success
 import java.io.File
-import java.io.IOException
 
 class StockFileItems(private val stockFile: File) : Items<NoTX> {
 
     override fun <R> inTransaction(block: context(NoTX) () -> R) = block(NoTX)
 
-    context(IO, NoTX) override fun save(
+    context(IO, NoTX, Raise<StockListLoadingError.IOError>) override fun save(
         stockList: StockList
-    ): Result<StockList, StockListLoadingError.IOError> = try {
+    ): StockList {
         val versionFile = File.createTempFile(
             "${stockFile.nameWithoutExtension}-${stockList.lastModified}-",
             "." + stockFile.extension,
@@ -25,12 +22,10 @@ class StockFileItems(private val stockFile: File) : Items<NoTX> {
         stockList.saveTo(tempFile)
         if (!tempFile.renameTo(stockFile))
             error("Failed to rename temp to stockfile")
-        Success(stockList)
-    } catch (x: IOException) {
-        Failure(StockListLoadingError.IOError(x.message ?: "no message"))
+        return stockList
     }
 
-    context(IO, NoTX) override fun load(): Result<StockList, StockListLoadingError> =
+    context(IO, NoTX, Raise<StockListLoadingError>) override fun load(): StockList =
         stockFile.loadItems()
 }
 

--- a/src/main/java/com/gildedrose/persistence/persisting.kt
+++ b/src/main/java/com/gildedrose/persistence/persisting.kt
@@ -1,9 +1,11 @@
 package com.gildedrose.persistence
 
+import arrow.core.raise.Raise
+import arrow.core.raise.ensure
 import com.gildedrose.domain.*
 import com.gildedrose.foundation.IO
+import com.gildedrose.foundation.withException
 import com.gildedrose.persistence.StockListLoadingError.*
-import dev.forkhandles.result4k.*
 import java.io.File
 import java.io.IOException
 import java.time.Instant
@@ -12,9 +14,8 @@ import java.time.format.DateTimeParseException
 
 private const val lastModifiedHeader = "# LastModified:"
 
-context(IO)
-@kotlin.jvm.Throws(IOException::class)
-fun StockList.saveTo(file: File) {
+context(IO, Raise<IOError>)
+fun StockList.saveTo(file: File) = withException(::IOError) {
     file.writer().buffered().use { writer ->
         this.toLines().forEach(writer::appendLine)
     }
@@ -23,64 +24,61 @@ fun StockList.saveTo(file: File) {
 fun StockList.toLines(): Sequence<String> = sequenceOf("$lastModifiedHeader $lastModified") +
     items.map { it.toLine() }
 
-context(IO)
-fun File.loadItems(): Result4k<StockList, StockListLoadingError> =
-    try {
-        useLines { lines ->
-            lines.toStockList()
-        }
-    } catch (x: IOException) {
-        Failure(IOError(x.message ?: "no message"))
-    }
+context(IO, Raise<StockListLoadingError>)
+fun File.loadItems(): StockList = withException(::IOError) {
+    useLines { lines -> lines.toStockList() }
+}
 
-fun Sequence<String>.toStockList(): Result4k<StockList, StockListLoadingError> {
+context(Raise<StockListLoadingError>)
+fun Sequence<String>.toStockList(): StockList {
     val (header, body) = partition { it.startsWith("#") }
-    val items: List<Item> = body.map { line -> line.toItem().onFailure { return it } }
-    return lastModifiedFrom(header).map { lastModified ->
-        StockList(
-            lastModified = lastModified ?: Instant.EPOCH,
-            items = items
-        )
-    }
+    val items: List<Item> = body.map { line -> line.toItem() }
+    return StockList(
+        lastModified = lastModifiedFrom(header) ?: Instant.EPOCH,
+        items = items
+    )
 }
 
 private fun Item.toLine() = "$id\t$name\t${sellByDate ?: ""}\t$quality"
 
+context(Raise<CouldntParseLastModified>)
 private fun lastModifiedFrom(
     header: List<String>
-): Result<Instant?, CouldntParseLastModified> = header
+): Instant? = header
     .lastOrNull { it.startsWith(lastModifiedHeader) }
     ?.substring(lastModifiedHeader.length)
     ?.trim()
-    ?.toInstant() ?: Success(null)
+    ?.toInstant()
 
-private fun String.toInstant(): Result<Instant, CouldntParseLastModified> =
-    try {
-        Success(Instant.parse(this))
-    } catch (x: DateTimeParseException) {
-        Failure(CouldntParseLastModified("Could not parse LastModified header: " + x.message))
+context(Raise<CouldntParseLastModified>)
+private fun String.toInstant(): Instant =
+    withException(::CouldntParseLastModifiedHeader) {
+        Instant.parse(this)
     }
 
-private fun String.toItem(): Result4k<Item, StockListLoadingError> {
+context(Raise<StockListLoadingError>)
+private fun String.toItem(): Item {
     val parts: List<String> = this.split('\t')
-    return when {
-        parts.size < 4 -> Failure(NotEnoughFields(this))
-        else -> itemWithIdFrom(parts)
-    }
+    ensure(parts.size >= 4) { NotEnoughFields(this) }
+    return itemWithIdFrom(parts)
 }
 
-private fun String.itemWithIdFrom(parts: List<String>): Result<Item, StockListLoadingError> {
-    val id = ID<Item>(parts[0]) ?: return Failure(BlankID(this))
-    val name = NonBlankString(parts[1]) ?: return Failure(BlankName(this))
-    val sellByDate = parts[2].toLocalDate(this).onFailure { return it }
-    val quality = parts[3].toIntOrNull()?.let { Quality(it) } ?: return Failure(CouldntParseQuality(this))
-    return Success(Item(id, name, sellByDate, quality))
+context(Raise<StockListLoadingError>)
+private fun String.itemWithIdFrom(parts: List<String>): Item {
+    val id = ID<Item>(parts[0]) ?: raise(BlankID(this))
+    val name = NonBlankString(parts[1]) ?: raise(BlankName(this))
+    val sellByDate = parts[2].toLocalDate(this)
+    val quality = parts[3].toIntOrNull()?.let { Quality(it) } ?: raise(CouldntParseQuality(this))
+    return Item(id, name, sellByDate, quality)
 }
 
-private fun String.toLocalDate(line: String): Result<LocalDate?, CouldntParseSellBy> =
-    try {
-        Success(if (this.isBlank()) null else LocalDate.parse(this))
-    } catch (x: DateTimeParseException) {
-        Failure(CouldntParseSellBy(line))
+context(Raise<CouldntParseSellBy>)
+private fun String.toLocalDate(line: String): LocalDate? =
+    withException({ _: DateTimeParseException -> CouldntParseSellBy(line) }) {
+        if (this.isBlank()) null else LocalDate.parse(this)
     }
 
+private fun IOError(exception: IOException): IOError = IOError(exception.message ?: "no message")
+
+private fun CouldntParseLastModifiedHeader(exception: DateTimeParseException): CouldntParseLastModified =
+    CouldntParseLastModified("Could not parse LastModified header: " + exception.message)

--- a/src/main/java/com/gildedrose/routes.kt
+++ b/src/main/java/com/gildedrose/routes.kt
@@ -1,23 +1,25 @@
 package com.gildedrose
 
+import arrow.core.raise.*
 import com.gildedrose.domain.*
 import com.gildedrose.foundation.AnalyticsEvent
+import com.gildedrose.foundation.magic
 import com.gildedrose.foundation.runIO
 import com.gildedrose.http.ResponseErrors
 import com.gildedrose.http.ResponseErrors.withError
 import com.gildedrose.http.catchAll
 import com.gildedrose.http.reportHttpTransactions
 import com.gildedrose.rendering.render
+import java.time.Duration
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
 import org.http4k.core.*
+import org.http4k.core.body.Form
 import org.http4k.core.body.form
 import org.http4k.filter.ServerFilters
 import org.http4k.lens.*
-import org.http4k.lens.ParamMeta.IntegerParam
 import org.http4k.routing.bind
 import org.http4k.routing.routes
-import java.time.Duration
-import java.time.LocalDate
-
 
 val App.routes: HttpHandler
     get() = ServerFilters.RequestTracing()
@@ -33,39 +35,53 @@ val App.routes: HttpHandler
             )
         )
 
-internal fun App.addHandler(request: Request): Response {
-    val idLens = FormField.nonBlankString().map { ID<Item>(it) }.required("new-itemId")
-    val nameLens = FormField.nonBlankString().required("new-itemName")
-    val sellByLens = FormField.nullOnEmptyLocalDate().optional("new-itemSellBy")
-    val qualityLens = FormField.nonNegativeInt().map { Quality(it) }.required("new-itemQuality")
-    val formBody = Body.webForm(Validator.Feedback, idLens, nameLens, sellByLens, qualityLens).toLens()
-    val form: WebForm = formBody(request)
-    if (form.errors.isNotEmpty())
-        return Response(Status.BAD_REQUEST).withError(NewItemFailedEvent(form.errors.toString()))
-
-    val item = Item(idLens(form), nameLens(form), sellByLens(form), qualityLens(form))
-    runIO {
-        addItem(newItem = item)
-    }
-    return Response(Status.SEE_OTHER).header("Location", "/")
+internal fun App.addHandler(request: Request): Response = recover({
+    val form = request.form()
+    val item = Item(
+        form.required("new-itemId") { ID(it) },
+        form.required("new-itemName") { NonBlankString(it) },
+        form.optional("new-itemSellBy") { it?.ifEmpty { null }?.toLocalDate() },
+        form.required("new-itemQuality") { Quality(it.toIntSafe()) })
+    runIO { addItem(newItem = item) }
+    Response(Status.SEE_OTHER).header("Location", "/")
+}) { error ->
+    Response(Status.BAD_REQUEST).withError(NewItemFailedEvent(error))
 }
 
 data class NewItemFailedEvent(val message: String) : AnalyticsEvent
 
-fun FormField.nonNegativeInt() =
-    mapWithNewMeta(
-        BiDiMapping<String, NonNegativeInt>(
-            { NonNegativeInt(it.toInt()) ?: throw IllegalArgumentException("Integer cannot be negative") },
-            NonNegativeInt::toString
-        ), IntegerParam
-    )
+context(Raise<String>)
+fun Form.required(name: String): String =
+    findSingle(name) ?: raise("formData '$name' is required")
 
-fun FormField.nullOnEmptyLocalDate() = string().map { if (it.isEmpty()) null else LocalDate.parse(it) }
+fun Form.optional(name: String): String? = findSingle(name)
 
-fun FormField.nonBlankString(): BiDiLensSpec<WebForm, NonBlankString> =
-    map(BiDiMapping<String, NonBlankString>({ s: String ->
-        NonBlankString(s) ?: throw IllegalArgumentException("String cannot be blank")
-    }, { it.toString() }))
+// The following 2 functions take care of including the invalid field name in the error message.
+context(Raise<String>)
+fun <T> Form.required(name: String, transform: context(Raise<String>) (String) -> T): T {
+    val value = required(name)
+    return withError({ e -> "formData '$name': $e" }) {
+        transform(magic(), value)
+    }
+}
+
+context(Raise<String>)
+fun <T> Form.optional(name: String, transform: context(Raise<String>) (String?) -> T): T {
+    val value = optional(name)
+    return withError({ e -> "formData '$name': $e" }) {
+        transform(magic(), value)
+    }
+}
+
+// In a Raise world, these would already be defined instead of their exception-throwing counterparts
+context(Raise<String>)
+fun String.toLocalDate(): LocalDate =
+    // This catch function is reified! So it only catches DateTimeParseException
+    catch<DateTimeParseException, _>({ LocalDate.parse(this) }) { raise("Invalid date format") }
+
+context(Raise<String>)
+fun String.toIntSafe(): Int =
+    catch<NumberFormatException, _>({ toInt() }) { raise("Invalid number format") }
 
 private fun App.listHandler(
     @Suppress("UNUSED_PARAMETER") request: Request

--- a/src/test/java/com/gildedrose/AddItemTests.kt
+++ b/src/test/java/com/gildedrose/AddItemTests.kt
@@ -186,7 +186,7 @@ class AddItemTests {
             app.addHandler(postWithTwoMissingFields),
             hasStatus(Status.BAD_REQUEST) and
                 hasAttachedError(
-                    NewItemFailedEvent("[formData 'new-itemId' is required, formData 'new-itemQuality' must be integer]")
+                    NewItemFailedEvent("[formData 'new-itemId' is required, formData 'new-itemQuality': Invalid number format]")
                 )
         )
     }

--- a/src/test/java/com/gildedrose/Fixture.kt
+++ b/src/test/java/com/gildedrose/Fixture.kt
@@ -6,10 +6,7 @@ import com.gildedrose.domain.PricedStockList
 import com.gildedrose.domain.StockList
 import com.gildedrose.foundation.IO
 import com.gildedrose.foundation.runIO
-import com.gildedrose.persistence.InMemoryItems
-import com.gildedrose.persistence.Items
-import com.gildedrose.persistence.TXContext
-import com.gildedrose.persistence.transactionally
+import com.gildedrose.persistence.*
 import dev.forkhandles.result4k.valueOrNull
 
 data class Fixture(

--- a/src/test/java/com/gildedrose/ListStockTests.kt
+++ b/src/test/java/com/gildedrose/ListStockTests.kt
@@ -1,5 +1,6 @@
 package com.gildedrose
 
+import arrow.core.raise.Raise
 import com.gildedrose.domain.*
 import com.gildedrose.foundation.IO
 import com.gildedrose.persistence.*
@@ -7,7 +8,6 @@ import com.gildedrose.testing.IOResolver
 import com.gildedrose.testing.fake
 import com.natpryce.hamkrest.assertion.assertThat
 import dev.forkhandles.result4k.Failure
-import dev.forkhandles.result4k.Result
 import dev.forkhandles.result4k.Success
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
@@ -61,8 +61,9 @@ class ListStockTests {
         val itemsThatFails = object : Items<NoTX> by fake() {
             override fun <R> inTransaction(block: context(NoTX) () -> R) = block(NoTX)
 
-            context(IO, NoTX) override fun load(): Result<StockList, StockListLoadingError> {
-                return Failure(expectedError)
+            context(IO, NoTX, Raise<StockListLoadingError>)
+            override fun load(): StockList {
+                raise(expectedError)
             }
         }
         val events: MutableList<Any> = mutableListOf()

--- a/src/test/java/com/gildedrose/persistence/InMemoryItems.kt
+++ b/src/test/java/com/gildedrose/persistence/InMemoryItems.kt
@@ -1,9 +1,8 @@
 package com.gildedrose.persistence
 
+import arrow.core.raise.Raise
 import com.gildedrose.domain.StockList
 import com.gildedrose.foundation.IO
-import dev.forkhandles.result4k.Result
-import dev.forkhandles.result4k.Success
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
 
@@ -14,14 +13,12 @@ class InMemoryItems(
 
     override fun <R> inTransaction(block: context(NoTX) () -> R) = block(NoTX)
 
-    context(IO, NoTX) override fun save(
-        stockList: StockList
-    ): Result<StockList, StockListLoadingError.IOError> {
+    context(IO, NoTX, Raise<StockListLoadingError.IOError>)
+    override fun save(stockList: StockList): StockList {
         this@InMemoryItems.stockList.set(stockList)
-        return Success(stockList)
+        return stockList
     }
 
-    context(IO, NoTX) override fun load(): Result<StockList, StockListLoadingError> {
-        return Success(stockList.get())
-    }
+    context(IO, NoTX, Raise<StockListLoadingError>)
+    override fun load(): StockList = stockList.get()
 }

--- a/src/test/java/com/gildedrose/testing/asserting.kt
+++ b/src/test/java/com/gildedrose/testing/asserting.kt
@@ -1,4 +1,12 @@
+@file:OptIn(ExperimentalTypeInference::class)
 package com.gildedrose.testing
+
+import arrow.core.raise.Raise
+import arrow.core.raise.merge
+import arrow.core.raise.recover
+import com.gildedrose.foundation.magic
+import kotlin.experimental.ExperimentalTypeInference
+import kotlin.test.assertEquals
 
 fun <T> assertAll(subject: T, vararg assertions: (T).() -> Unit) {
     assertAll(subject, assertions.toList())
@@ -11,4 +19,21 @@ fun <T> assertAll(subject: T, assertions: Iterable<(T).() -> Unit>) {
         }
         org.junit.jupiter.api.assertAll(this.toString(), convertedAssertions)
     }
+}
+
+inline fun <E, R> assertSucceeds(@BuilderInference block: Raise<E>.() -> R): R =
+    recover(block) { error("Unexpected raised error: $it") }
+
+inline fun <E, R> assertSucceedsWith(result: R, @BuilderInference block: Raise<E>.() -> R) {
+  assertEquals(result, assertSucceeds(block))
+}
+
+inline fun <E, R> assertFails(@BuilderInference block: Raise<E>.() -> R): E =
+    merge {
+        block(magic())
+        error("Expected raised error")
+    }
+
+inline fun <E, R> assertFailsWith(error: E, @BuilderInference block: Raise<E>.() -> R) {
+    assertEquals(error, assertFails(block))
 }

--- a/src/test/java/com/gildedrose/updating/StockTests.kt
+++ b/src/test/java/com/gildedrose/updating/StockTests.kt
@@ -5,9 +5,9 @@ import com.gildedrose.foundation.IO
 import com.gildedrose.item
 import com.gildedrose.oct29
 import com.gildedrose.persistence.InMemoryItems
+import com.gildedrose.persistence.transactionally
 import com.gildedrose.testing.IOResolver
 import dev.forkhandles.result4k.valueOrNull
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.Instant
@@ -15,6 +15,7 @@ import java.time.ZoneId
 import java.util.concurrent.Callable
 import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.Executors
+import kotlin.test.assertEquals
 
 @ExtendWith(IOResolver::class)
 class StockTests {
@@ -40,7 +41,7 @@ class StockTests {
         val now = Instant.parse("2022-02-09T23:59:59Z")
         assertEquals(
             initialStockList,
-            items.inTransaction { stock.loadAndUpdateStockList(now).valueOrNull() }
+            items.transactionally { stock.loadAndUpdateStockList(now) }.valueOrNull()
         )
     }
 
@@ -57,11 +58,12 @@ class StockTests {
         )
         assertEquals(
             expectedUpdatedResult,
-            items.inTransaction { stock.loadAndUpdateStockList(now).valueOrNull() }
+            items.transactionally { stock.loadAndUpdateStockList(now) }.valueOrNull()
         )
-        items.inTransaction {
-            assertEquals(expectedUpdatedResult, items.load().valueOrNull())
-        }
+        assertEquals(
+            expectedUpdatedResult,
+            items.transactionally { load() }.valueOrNull()
+        )
     }
 
     context(IO)
@@ -77,11 +79,12 @@ class StockTests {
         )
         assertEquals(
             expectedUpdatedResult,
-            items.inTransaction { stock.loadAndUpdateStockList(now).valueOrNull() }
+            items.transactionally { stock.loadAndUpdateStockList(now) }.valueOrNull()
         )
-        items.inTransaction {
-            assertEquals(expectedUpdatedResult, items.load().valueOrNull())
-        }
+        assertEquals(
+            expectedUpdatedResult,
+            items.transactionally { load() }.valueOrNull()
+        )
     }
 
     context(IO)
@@ -90,11 +93,12 @@ class StockTests {
         val now = Instant.parse("2022-02-08T00:00:01Z")
         assertEquals(
             initialStockList,
-            items.inTransaction { stock.loadAndUpdateStockList(now).valueOrNull() }
+            items.transactionally { stock.loadAndUpdateStockList(now) }.valueOrNull()
         )
-        items.inTransaction {
-            assertEquals(initialStockList, items.load().valueOrNull())
-        }
+        assertEquals(
+            initialStockList,
+            items.transactionally { load() }.valueOrNull()
+        )
     }
 
     context(IO)


### PR DESCRIPTION
I won't provide too much info here, partially as a test to see if `Raise` is as intuitive as claimed ;D. This change seems to have de-cluttered certain parts of the main application code, but it had some impact on test code (although that was easily alleviated with some asserting.kt utils).

I cheated a little bit by modifying `transactionally` to also do the Raise-to-Result4k conversion, but that's because nearly everywhere that `transactionally` was used, a `Result4k` was expected, and so it prevented boilerplate-y changes to test code.

Importantly, this change helped highlight some places where errors were ignored. These places now have `ignoreErrors` because `Raise` forces us to handle the errors somehow, we can't just leave them ignored.

A really nice result of this refactor is that exceptions are being converted to domain errors at the earliest possible site, and hence this removes a lot of magical `try-catch`es that were present previously. `withException` seems like quite a useful utility btw, to the point that I might make a PR to Arrow to add it.

I chose to use `Result4k` at the far edges of the program (e.g. in `App`, rendering, and tests). There were some places like mismatch reporting and pricing where it also made sense to use `Result4k`, so it's still being used there. What's nice is that its usage is now mainly as a way to *hold* values that might've failed, but it's not used as the main way to pass them around and return them anymore.

Arrow's `Either` would work well as a drop-in replacement for `Result4k`, but I deliberately didn't use it to show just how easy it is to adopt `Raise` for any data type depending on your needs.